### PR TITLE
修复README中的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](https://github.githubassets.com/images/icons/emoji/tada.png)
 
-[**GitHub**](https://github.com/zkitefly/TranslationPackConvert) · [**GitCode**](https://gitcode.net/chearlai/translationpackmirror)
+[**GitHub**](https://github.com/zkitefly/TranslationPackConvert) · [**GitCode**](https://gitcode.net/chearlai/translationpackconvert)
 
 **一个将  CFPAOrg/Minecraft-Mod-Language-Package 翻译包转换的自动化仓库**
 
@@ -38,7 +38,7 @@
 
 - 手动：
 
-#### **普通用户请到此处下载：[https://gitcode.net/chearlai/translationpackmirror/-/tree/main/files](https://gitcode.net/chearlai/translationpackmirror/-/tree/main/files)**
+#### **普通用户请到此处下载：[https://gitcode.net/chearlai/translationpackconvert/-/tree/main/files](https://gitcode.net/chearlai/translationpackconvert/-/tree/main/files)**
 
 #### 下载时请留意文件后缀对应支持的 MC 版本和 Modloader（也就是Forge、Fabric等）类型。
 
@@ -61,11 +61,11 @@
 
 ### **☆推荐☆**
 
-**https://gitcode.net/chearlai/translationpackmirror/-/raw/main/files/ + [本仓库所含的 zip 文件](https://github.com/zkitefly/TranslationPackMirror/tree/main/files)**
+**https://gitcode.net/chearlai/translationpackconvert/-/raw/main/files/ + [本仓库所含的 zip 文件](https://github.com/zkitefly/TranslationPackConvert/tree/main/files)**
 
 例如：
 
-**https://gitcode.net/chearlai/translationpackmirror/-/raw/main/files/Minecraft-Mod-Language-Modpack-1-16T1-17.zip**
+**https://gitcode.net/chearlai/translationpackconvert/-/raw/main/files/Minecraft-Mod-Language-Modpack-1-16T1-17.zip**
 
 
 ### 其他
@@ -124,7 +124,7 @@
 
 ☆
 
-*https://gitcode.net/chearlai/TranslationPackMirror/-/raw/main/files/Minecraft-Mod-Language-Modpack-1-16.zip*
+*https://gitcode.net/chearlai/translationpackconvert/-/raw/main/files/Minecraft-Mod-Language-Modpack-1-16.zip*
 
 平均 6.20 MB/s  用时 0.6s
 


### PR DESCRIPTION
部分链接被链接的是镜像仓库而不是转换仓库